### PR TITLE
Check for device name made more robust

### DIFF
--- a/encled
+++ b/encled
@@ -179,7 +179,7 @@ def main(argv):
         return(0)
 
     if os.path.exists(argv[1]):
-	devname = os.path.realpath(argv[1]);
+        devname = os.path.realpath(argv[1]);
         name = devname.lower().split('/')[-1]
         for d in devlist:
             if(d[3][0] == name):

--- a/encled
+++ b/encled
@@ -178,8 +178,10 @@ def main(argv):
             if result: return(result)
         return(0)
 
-    if 'sd' in argv[1] or '/dev' in argv[1]:
-        name = argv[1].lower().split('/')[-1]
+    #if 'sd' in argv[1] or '/dev' in argv[1]:
+    if os.path.exists(argv[1]):
+	devname = os.path.realpath(argv[1]);
+        name = devname.lower().split('/')[-1]
         for d in devlist:
             if(d[3][0] == name):
                 dev = d

--- a/encled
+++ b/encled
@@ -178,7 +178,6 @@ def main(argv):
             if result: return(result)
         return(0)
 
-    #if 'sd' in argv[1] or '/dev' in argv[1]:
     if os.path.exists(argv[1]):
 	devname = os.path.realpath(argv[1]);
         name = devname.lower().split('/')[-1]


### PR DESCRIPTION
The test to see if a device name is specified (as opposed to 'ALL' or a slot specification) is made a bit more robust. It now also works for symbolic links to the block devices. This is useful when using symbolic links under /dev/disk/.