### PR TITLE
Port to python3

### DIFF
--- a/encled
+++ b/encled
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/encled
+++ b/encled
@@ -180,7 +180,7 @@ def main(argv):
                 result = set_status(d[2], argv[2].lower())
                 if result: return(result)
             elif ((d[3][1]).upper()).replace(" ", "") == 'FAULT_ON' and argv[2].upper().replace(" ", "") == 'LOCATE':
-                result = set_status(d[2], argv[2].lower())     
+                result = set_status(d[2], argv[2].lower())
                 if result: return(result)
         return(0)
 

--- a/encled
+++ b/encled
@@ -101,14 +101,14 @@ def get_status(path):
     except OSError:
         block = '----'
     try:
-        if int(file(os.path.join(path, 'fault'), 'r').readline().strip()):
+        if int(open(os.path.join(path, 'fault'), 'r').readline().strip()):
             fault = ' FAULT_ON'
         else:
             fault = 'fault_off'
     except OSError:
         fault = 'fault_N/A'
     try:
-        if int(file(os.path.join(path, 'locate'), 'r').readline().strip()):
+        if int(open(os.path.join(path, 'locate'), 'r').readline().strip()):
             locate = ' LOCATE_ON'
         else:
             locate = 'locate_off'
@@ -123,12 +123,12 @@ def set_status(path, status):
         status is 'fault' or 'locate' or 'off'
     '''
     if status == 'fault':
-        file(os.path.join(path, 'fault'), 'w').write('1')
+        open(os.path.join(path, 'fault'), 'w').write('1')
     elif status == 'locate' or status == 'loc':
-        file(os.path.join(path, 'locate'), 'w').write('1')
+        open(os.path.join(path, 'locate'), 'w').write('1')
     elif status == 'off':
-        file(os.path.join(path, 'fault'), 'w').write('0')
-        file(os.path.join(path, 'locate'), 'w').write('0')
+        open(os.path.join(path, 'fault'), 'w').write('0')
+        open(os.path.join(path, 'locate'), 'w').write('0')
     else:
         print("encled: Wrong status (%s)" % str(status))
         return -1

--- a/encled
+++ b/encled
@@ -130,7 +130,7 @@ def set_status(path, status):
         open(os.path.join(path, 'fault'), 'w').write('0')
         open(os.path.join(path, 'locate'), 'w').write('0')
     else:
-        print("encled: Wrong status (%s)" % str(status))
+        print(f"encled: Wrong status {status}")
         return -1
 
 
@@ -141,7 +141,7 @@ def print_status(enc, slot, status):
     else:
         out = out + '(Not available)'
     out = out
-    print ("%s" % out)
+    print(out)
 
 
 def list_all():
@@ -197,7 +197,7 @@ def main(argv):
                 dev = d
                 break
         else:
-            print("encled: Unable to find device %s in enclosure slots. (note: on-board SATA ports are not supported)" % str(name))
+            print(f"encled: Unable to find device {name} in enclosure slots. (note: on-board SATA ports are not supported)")
             return(-1)
 
     elif '/' in argv[1]:

--- a/sdled
+++ b/sdled
@@ -23,13 +23,13 @@ def sd_list():
     """
     return list of all sd devices in /sys/block
     """
-    return filter(lambda x: "sd" in x, os.listdir("/sys/block"))
+    return [x for x in os.listdir("/sys/block") if "sd" in x]
 
 def go_to_enc(dev):
     enc="enclosure_device" #magik string to access enclosure data
     try:
         os.chdir("/sys/block/"+dev+"/device")
-        l=filter(lambda x: enc in x, os.listdir("."))
+        l=[x for x in os.listdir(".") if enc in x]
         os.chdir(l[0])
         return True
     except:

--- a/sdled
+++ b/sdled
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 import os,sys
 
 help="""

--- a/sdled
+++ b/sdled
@@ -43,8 +43,8 @@ def get_status(dev):
     if not go_to_enc(dev):
         return "N/A" #No magic path, can't get status
     try:
-        fault=int(file("fault",'r').readline())
-        locate=int(file("locate",'r').readline())
+        fault=int(open("fault",'r').readline())
+        locate=int(open("locate",'r').readline())
         if(fault):
             return "fault"
         if(locate):
@@ -58,12 +58,12 @@ def set_status(device, status):
         print("Device %s not supported"%(device))
         return False
     if status == "off":
-       file("locate","w").write('0')
+       open("locate","w").write('0')
        return True
     if not status in ("fault", "locate"):
         print("bad status. Use: off, fault, locate")
         return False
-    file(status, "w").write('1')
+    open(status, "w").write('1')
     return True #no try/exect - if something wrong, do not hide it
 
 sys.stderr.write("sdled is deprecated. Use encled\n")

--- a/sdled
+++ b/sdled
@@ -55,7 +55,7 @@ def get_status(dev):
 
 def set_status(device, status):
     if not go_to_enc(device):
-        print("Device %s not supported"%(device))
+        print(f"Device {device} not supported")
         return False
     if status == "off":
        open("locate","w").write('0')

--- a/sdled
+++ b/sdled
@@ -55,13 +55,13 @@ def get_status(dev):
 
 def set_status(device, status):
     if not go_to_enc(device):
-        print "Device %s not supported"%(device)
+        print("Device %s not supported"%(device))
         return False
     if status == "off":
        file("locate","w").write('0')
        return True
     if not status in ("fault", "locate"):
-        print "bad status. Use: off, fault, locate"
+        print("bad status. Use: off, fault, locate")
         return False
     file(status, "w").write('1')
     return True #no try/exect - if something wrong, do not hide it
@@ -69,13 +69,13 @@ def set_status(device, status):
 sys.stderr.write("sdled is deprecated. Use encled\n")
 
 if len(sys.argv)<2:
-    print "DEVICE NAME      STATUS"
+    print("DEVICE NAME      STATUS")
     for d in sd_list():
-        print ("/dev/"+d).ljust(17),  get_status(d)
+        print("/dev/"+d.ljust(17) + get_status(d))
     sys.exit(0)
 if len(sys.argv)==3:
     if sys.argv[1]=="--help" or sys.argv[1]=="-h":
-        print help
+        print(help)
         sys.exit(0)
 
 if sys.argv[1]=="ALL":
@@ -92,7 +92,7 @@ else:
     device = sys.argv[1]
 
 if len(sys.argv)==2:
-    print get_status(device)
+    print(get_status(device))
     sys.exit(-1)
 
 set_status(device,sys.argv[2])

--- a/sdled
+++ b/sdled
@@ -5,8 +5,8 @@ help="""
     Usage:
     sdled (without options) - display all sd* devices status
     sdled /dev/sd[letter] - display status of requested device
-    sdled /dev/sd[letter] faul - set led indicator to 'faulty' 
-                          this WILL NOT make device faulty, just set 
+    sdled /dev/sd[letter] faul - set led indicator to 'faulty'
+                          this WILL NOT make device faulty, just set
                           enclosure led to 'FAULTY' status.
     sdled /dev/sd[letter] locate - set led indicator to 'locate' status
     sdled /dev/sd[letter] off - turn of faulty/locate status
@@ -85,7 +85,7 @@ if sys.argv[1]=="ALL":
        except:
            pass
    sys.exit(0)
-   
+
 if ("/" in sys.argv[1]):
     device = sys.argv[1].split('/')[-1]
 else:
@@ -96,4 +96,3 @@ if len(sys.argv)==2:
     sys.exit(-1)
 
 set_status(device,sys.argv[2])
-


### PR DESCRIPTION
python2 is two years as no longer maintained, so let's finally migrate to python3.

As a side effect this will also fix the problem with `./encled` and `./sdled` on Ubuntu-Server 22.04 system failing with

```
/usr/bin/env: ‘python’: No such file or directory
```

as for some reason they don't have `python` binary in $PATH.